### PR TITLE
Update fw_update.sh to support V3 USB Lookup

### DIFF
--- a/fw_update.sh
+++ b/fw_update.sh
@@ -172,6 +172,7 @@ def parse_blocks(lines):
     canbus = None
     serial = None
     section_for_canbus = None
+    section_for_serial = None
     current_section = None
     in_block = False
     for line in lines:
@@ -198,18 +199,20 @@ def parse_blocks(lines):
         m = re.search(r"serial\s*[:=]\s*(.+)$", raw, re.I)
         if m:
             serial = m.group(1).split("#")[0].strip().strip('"').strip("'")
+            section_for_serial = current_section
             continue
-    return canbus, serial, section_for_canbus
+    return canbus, serial, section_for_canbus, section_for_serial
 
 
 with open(path, "r", errors="replace") as fh:
     lines = fh.readlines()
 
-canbus, serial, section_for_canbus = parse_blocks(lines)
+canbus, serial, section_for_canbus, section_for_serial = parse_blocks(lines)
 if canbus:
     print("CANBUS|" + canbus)
-if section_for_canbus:
-    print("SECTION|" + section_for_canbus)
+section_name = section_for_canbus or section_for_serial
+if section_name:
+    print("SECTION|" + section_name)
 if serial:
     print("SERIAL|" + serial)
 PY
@@ -538,7 +541,7 @@ detect_probe() {
         json="$(query_moonraker_mcu_object "$moon_kind" || true)"
         extract_canbus_frequency "$json" || true
     else
-        json="$(query_moonraker_mcu_object cartographer || true)"
+        json="$(query_moonraker_mcu_object "$moon_kind" || true)"
     fi
 
     extract_current_fw_from_moonraker_json "$json" || true


### PR DESCRIPTION
Updated fw_update.sh to support V3 probe lookup and flash. Utilize Moon_Kind over cartographer object. Cartographer lookup would never find my scanner definition. Supports open Issue #4 being able to be closed I'm pretty sure..

Issue:
'
+------------------------------------------------------------------------------------------+
|                                   Detecting your probe                                   |
+------------------------------------------------------------------------------------------+
|                                                                                          |
|  Klippy log: found                                                                       |
|  /home/mks/printer_data/logs/klippy.log                                                  |
|                                                                                          |
|  [mcu cartographer] / [mcu scanner]: found                                               |
|  /home/mks/printer_data/logs/klippy.log                                                  |
|  (+ 1 more file(s))                                                                      |
|                                                                                          |
|  Parsed serial: /dev/serial/by-id/usb-Cartographer_614e_140032000E4330394D363620-if00    |
|                                                                                          |
|  Link for firmware lookup: USB                                                           |
|                                                                                          |
|  Could not determine probe type automatically.                                           |
|  Check that klippy.log lists [mcu cartographer] or [mcu                                  |
|  scanner], and Moonraker is reachable for USB probes.                                    |
|                                                                                          |
+------------------------------------------------------------------------------------------+

Press Enter to continue...
'

Solution Results: Updated V3 USB to 6.1.0.
'+------------------------------------------------------------------------------------------+
|                                   Detecting your probe                                   |
+------------------------------------------------------------------------------------------+
|                                                                                          |
|  Klippy log: found                                                                       |
|  /home/mks/printer_data/logs/klippy.log                                                  |
|                                                                                          |
|  [mcu cartographer] / [mcu scanner]: found                                               |
|  /home/mks/printer_data/logs/klippy.log                                                  |
|  (+ 1 more file(s))                                                                      |
|                                                                                          |
|  Parsed serial: /dev/serial/by-id/usb-Cartographer_614e_140032000E4330394D363620-if00    |
|                                                                                          |
|  Link for firmware lookup: USB                                                           |
|                                                                                          |
|  V3 detected.                                                                            |
|  Moonraker reports MCU stm32f042x6 for [mcu cartographer].                               |
|                                                                                          |
|                                                                                          |
+------------------------------------------------------------------------------------------+

Press Enter to continue...
'